### PR TITLE
Revert "Revert "Supports adding additional context required to build, and uses branch…""

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+sphinx_multiversion.egg-info/
+__pycache__/

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -171,6 +171,12 @@ def main(argv=None):
         action="store_true",
         help="dump generated metadata and exit",
     )
+    parser.add_argument(
+        "--additional-context",
+        nargs="*",
+        default=[],
+        help="additional paths-from-gitroot that must be copied to build docs",
+    )
     args, argv = parser.parse_known_args(argv)
     if args.noconfig:
         return 1
@@ -238,15 +244,17 @@ def main(argv=None):
         for gitref in gitrefs:
             # Clone Git repo
             repopath = os.path.join(tmp, gitref.commit)
-            try:
-                git.copy_tree(str(gitroot), gitroot.as_uri(), repopath, gitref)
-            except (OSError, subprocess.CalledProcessError):
-                logger.error(
-                    "Failed to copy git tree for %s to %s",
-                    gitref.refname,
-                    repopath,
-                )
-                continue
+            for dir in (cwd_relative, *args.additional_context):
+                try:
+                    git.copy_tree(str(gitroot), gitroot.as_uri(), repopath, gitref, dir)
+                except (OSError, subprocess.CalledProcessError):
+                    logger.error(
+                        "Failed to copy git tree %s for %s to %s",
+                        dir,
+                        gitref.refname,
+                        repopath,
+                    )
+                    continue
 
             # Find config
             confpath = os.path.join(repopath, confdir)
@@ -339,8 +347,6 @@ def main(argv=None):
                     *defines,
                     "-D",
                     "smv_current_version={}".format(version_name),
-                    "-c",
-                    confdir_absolute,
                     "-w",
                     os.path.join(tmp, "smv-err.log"),
                     data["sourcedir"],
@@ -369,7 +375,7 @@ def main(argv=None):
                 }
             )
             subprocess.check_call(cmd, cwd=current_cwd, env=env)
-            
+
             if args.warningfile:
                 with open(args.warningfile, mode="a") as wf:
                     with open(os.path.join(tmp, "smv-err.log"), mode="r") as err_log:


### PR DESCRIPTION
Reverts jaiveersinghNV/sphinx-multiversion#3

Initial revert was because many usages were building from `master`; all usages are now pinned to specific commits, so it's okay to update `master` with breaking functionality